### PR TITLE
IT-148 - Droar - don’t auto-complete textfields

### DIFF
--- a/Droar/Classes/Cells/DroarTextFieldCell.xib
+++ b/Droar/Classes/Cells/DroarTextFieldCell.xib
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -25,16 +23,16 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="titleLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6cB-Oy-cFf">
-                        <rect key="frame" x="16" y="11" width="58.5" height="74"/>
+                        <rect key="frame" x="16" y="11" width="49" height="74"/>
                         <fontDescription key="fontDescription" name="RussoOne-Regular" family="Russo One" pointSize="12"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="test" borderStyle="roundedRect" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uHM-Ob-JJz">
-                        <rect key="frame" x="82" y="11" width="277" height="74"/>
+                        <rect key="frame" x="73" y="11" width="286" height="74"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" name="RussoOne-Regular" family="Russo One" pointSize="12"/>
-                        <textInputTraits key="textInputTraits"/>
+                        <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                         <connections>
                             <action selector="handleTextChanged:" destination="Njc-uR-RH6" eventType="editingChanged" id="atU-LQ-UtZ"/>
                         </connections>


### PR DESCRIPTION
Added Internal Task - IT-148
Droar - don’t auto-complete textfields
This is part of the DroarTextFieldCell.  Should be able to just edit that cell in the interface builder to not auto-complete textfields.