### PR TITLE
Make droar not the key window (in general)

### DIFF
--- a/Droar.podspec
+++ b/Droar.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Droar'
-  s.version          = '2.0.0'
+  s.version          = '2.0.1'
   s.summary          = 'A runtime debugging tool for iOS.'
 
   s.description      = <<-DESC

--- a/Droar/Classes/Droar Core/Droar.swift
+++ b/Droar/Classes/Droar Core/Droar.swift
@@ -101,11 +101,9 @@ extension Droar {
             navController.view.transform = CGAffineTransform(translationX: -navController.view.frame.size.width, y: 0)
             window.setActivationPercent(1)
         }) { (completed) in
-            
-            if let window = openRecognizer.view {
-                window.removeGestureRecognizer(openRecognizer)
-                window.addGestureRecognizer(dismissalRecognizer)
-            }
+            //Swap gestures
+            openRecognizer.view?.removeGestureRecognizer(openRecognizer)
+            window.addGestureRecognizer(dismissalRecognizer)
             
             completion?()
         }
@@ -118,10 +116,9 @@ extension Droar {
         }) { (completed) in
             window.isHidden = true
             
-            if let window = dismissalRecognizer.view {
-                window.removeGestureRecognizer(dismissalRecognizer)
-                replaceGestureRecognizer(with: openRecognizer)
-            }
+            //Swap gestures
+            dismissalRecognizer.view?.removeGestureRecognizer(dismissalRecognizer)
+            replaceGestureRecognizer(with: openRecognizer)
             
             completion?()
         }

--- a/Droar/Classes/Droar Core/DroarGestureHandler.swift
+++ b/Droar/Classes/Droar Core/DroarGestureHandler.swift
@@ -75,8 +75,10 @@ internal extension Droar {
     //Visibility Updates
     private static func beginDroarVisibilityUpdate() -> Bool {
         //Ensure the window is visible
+        let appWindow = loadKeyWindow()
         window.makeKeyAndVisible()
         window.addSubview(navController.view)
+        appWindow?.makeKeyAndVisible()
         
         //Update for knob state
         KnobManager.sharedInstance.registerDynamicKnobs(loadDynamicKnobs())


### PR DESCRIPTION
fixes issue where other libraries, like netfox, need the apps key window - not the droar window